### PR TITLE
feat: support links do have a discernible name on screen readers

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -9,7 +9,10 @@
         >
           <NavLink :link="item.link">
             <component :is="item.iconComponent"></component>
-            {{ item.text }}
+            <span v-if="item.showTextToScreenReaderOnly" class="sr-only">{{
+              item.text
+            }}</span
+            ><template v-else>{{ item.text }}</template>
           </NavLink>
         </li>
       </ul>
@@ -69,10 +72,12 @@ export default {
         (this.$themeConfig.footer && this.$themeConfig.footer.contact) ||
         []
       )
-        .map(({ type, link }) => {
+        .map(({ type, link, text, showTextToScreenReaderOnly }) => {
           return {
             iconComponent: this.getIconComponentName(type),
             link,
+            text,
+            showTextToScreenReaderOnly,
           }
         })
         .filter(({ iconComponent }) => iconComponent)

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -52,7 +52,7 @@ module.exports = {
 ### footer.contact
 
 
-- Type: `Array<{ type: ContactType, link: string }>`
+- Type: `Array<{ type: ContactType, link: string, text: string, showTextToScreenReaderOnly: bool }>`
 - Default: `undefined`
 
 Contact information, displayed on the left side of footer.
@@ -66,6 +66,8 @@ module.exports = {
         {
           type: 'github',
           link: 'https://github.com/vuejs/vuepress',
+          text: 'My Github',
+          showTextToScreenReaderOnly: true
         },
         {
           type: 'twitter',
@@ -76,6 +78,7 @@ module.exports = {
   },
 }
 ```
+When `showTextToScreenReaderOnly` is **true**, the value provided in `text` will showed only to screen readers
 
 For now `ContactType` supports following enums:
 
@@ -94,6 +97,12 @@ For now `ContactType` supports following enums:
 - video
 - web
 - youtube
+
+::: tip
+  You can use `showTextToScreenReaderOnly` to improves the navigation experience for users of screen readers and other assistive technologies
+  
+  [Ref: web.dev](https://web.dev/link-name/)
+:::
 
 ::: tip
 Welcome contribution of adding more built-in contact type.

--- a/example/.vuepress/config.js
+++ b/example/.vuepress/config.js
@@ -36,6 +36,8 @@ module.exports = {
         {
           type: 'codepen',
           link: '/',
+          text: 'codepen',
+          showTextToScreenReaderOnly: true
         },
         {
           type: 'codesandbox',

--- a/styles/index.styl
+++ b/styles/index.styl
@@ -3,6 +3,7 @@
 @require './code.styl'
 @require './wrapper.styl'
 @require './sw-popup.styl'
+@require './screen-reader.styl'
 
 html, body
   padding 0

--- a/styles/screen-reader.styl
+++ b/styles/screen-reader.styl
@@ -1,0 +1,9 @@
+.sr-only 
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
The current implementation is missing a "link text that is discernible, unique, and focusable" to improves the navigation experience for screen reader users. That PR enable an option to create a blog more accessible
- [x] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
Sorry to not open an issue first. I resolved that in my personal theme and decided to bring this for everyone. I can open an issue if necessary.

**Other information:**
web.dev reference: https://web.dev/link-name/