### PR TITLE
fix: remove markdown from content before slice

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,12 +137,9 @@ module.exports = themeConfig => {
       }
       if (themeConfig.summary) {
         pageCtx.summary =
-          removeMd(
-            strippedContent
-              .trim()
-              .replace(/^#+\s+(.*)/, '')
-              .slice(0, themeConfig.summaryLength)
-          ) + ' ...'
+          removeMd(strippedContent.trim())
+            .replace(/^#+\s+(.*)/, '')
+            .slice(0, themeConfig.summaryLength) + ' ...'
         pageCtx.frontmatter.description = pageCtx.summary
       }
       if (pageCtx.frontmatter.summary) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
The summary provided can contain a broken markdown.

We faced this issue on https://theheadless.dev when the summary were trimmed based on the configured characters, there were scenarios where the markdow was not valid anymore (please check the image attached).

This PR changes the logic to remove the markdown of the summary first and then slice the content. We introduce the same fix in our config and works as expected.

More info 
https://github.com/vuejs/vuepress/issues/2657
https://github.com/checkly/theheadless.dev/pull/84